### PR TITLE
use And to add more expectations to a Then

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,25 +81,25 @@ describe "eliminating redundant test execution", ->
 ```
 Because there are four `Then` statements, the `Given` and `When` are each executed four times. That's because it would be unreasonable for Jasmine to expect each `it` function  to be idempotent.
 
-However, spec authors can leverage idempotence safely when writing in a given-when-then format. You opt-in with jasmine-given by chaining `Then` blocks, as shown below:
+However, spec authors can leverage idempotence safely when writing in a given-when-then format. You opt-in with jasmine-given by using `And` blocks, as shown below:
 
 ``` coffeescript
   context "chaining Then statements", ->
     timesGivenWasInvoked = timesWhenWasInvoked = 0
     Given -> timesGivenWasInvoked++
     When -> timesWhenWasInvoked++
-    Then(-> timesGivenWasInvoked == 1)
-    .Then(-> timesWhenWasInvoked == 1)
-    .Then(-> timesGivenWasInvoked == 1)
-    .Then(-> timesWhenWasInvoked == 1)
+
+    Then -> timesGivenWasInvoked == 1
+    And -> timesWhenWasInvoked == 1
+    And -> timesGivenWasInvoked == 1
+    And -> timesWhenWasInvoked == 1
+
     Then -> timesWhenWasInvoked == 2
 ```
 
-In this example, `Given` and `When` are only invoked one time each, because jasmine-given rolled all of those `Then` statements up into a single `it` in Jasmine.
+In this example, `Given` and `When` are only invoked one time each for the first `Then, because jasmine-given rolled all of those `Then` & `And` statements up into a single `it` in Jasmine.  Note that the label of the `it` is taken from the `Then` only.
 
 Leveraging this feature is likely to have the effect of speeding up your specs, especially if your specs are otherwise slow (integration specs or DOM-heavy).
-
-[Note that in the above, each `Then` needed to be wrapped in parentheses in order for CoffeeScript to understand that we were chaining invocations. If there's a cleaner way to do this in CoffeeScript, please [let me know](https://github.com/searls/jasmine-given/issues/new)]
 
 The above spec can also be expressed in JavaScript:
 
@@ -123,9 +123,9 @@ describe("eliminating redundant test execution", function() {
     Given(function() { timesGivenWasInvoked++; });
     When(function() { timesWhenWasInvoked++; });
     Then(function() { return timesGivenWasInvoked == 1; })
-    .Then(function() { return timesWhenWasInvoked == 1; })
-    .Then(function() { return timesGivenWasInvoked == 1; })
-    .Then(function() { return timesWhenWasInvoked == 1; })
+    And(function() { return timesWhenWasInvoked == 1; })
+    And(function() { return timesGivenWasInvoked == 1; })
+    And(function() { return timesWhenWasInvoked == 1; })
   });
 });
 

--- a/spec/jasmine-given-js-spec.js
+++ b/spec/jasmine-given-js-spec.js
@@ -24,9 +24,21 @@ describe("jasmine-given JavaScript API", function() {
       Given(function() { timesGivenWasInvoked++; });
       When(function() { timesWhenWasInvoked++; });
       Then(function() { return timesGivenWasInvoked == 1; });
-      And(function() { return timesWhenWasInvoked == 2; });
-      And(function() { return timesGivenWasInvoked == 3; });
-      And(function() { return timesWhenWasInvoked == 4; });
+      Then(function() { return timesWhenWasInvoked == 2; });
+      Then(function() { return timesGivenWasInvoked == 3; });
+      Then(function() { return timesWhenWasInvoked == 4; });
+    });
+
+    context("using And statements", function() {
+      var timesGivenWasInvoked = 0,
+          timesWhenWasInvoked = 0;
+      Given(function() { timesGivenWasInvoked++; });
+      When(function() { timesWhenWasInvoked++; });
+      Then(function() { return timesGivenWasInvoked == 1; });
+      And(function() { return timesWhenWasInvoked == 1; });
+      And(function() { return timesGivenWasInvoked == 1; });
+      And(function() { return timesWhenWasInvoked == 1; });
+      Then(function() { return timesWhenWasInvoked == 2; })
     });
 
     context("chaining Then statements", function() {
@@ -38,6 +50,7 @@ describe("jasmine-given JavaScript API", function() {
       .And(function() { return timesWhenWasInvoked == 1; })
       .And(function() { return timesGivenWasInvoked == 1; })
       .And(function() { return timesWhenWasInvoked == 1; })
+      Then(function() { return timesWhenWasInvoked == 2; })
     });
   });
 

--- a/spec/jasmine-given-spec.coffee
+++ b/spec/jasmine-given-spec.coffee
@@ -21,9 +21,18 @@ describe "jasmine-given CoffeeScript API", ->
       Given -> timesGivenWasInvoked++
       When -> timesWhenWasInvoked++
       Then -> timesGivenWasInvoked == 1
-      And -> timesWhenWasInvoked == 2
-      And -> timesGivenWasInvoked == 3
-      And -> timesWhenWasInvoked == 4
+      Then -> timesWhenWasInvoked == 2
+      Then -> timesGivenWasInvoked == 3
+      Then -> timesWhenWasInvoked == 4
+
+    context "using And statements", ->
+      timesGivenWasInvoked = timesWhenWasInvoked = 0
+      Given -> timesGivenWasInvoked++
+      When -> timesWhenWasInvoked++
+      Then -> timesGivenWasInvoked == 1
+      And -> timesWhenWasInvoked == 1
+      And -> timesGivenWasInvoked == 1
+      And -> timesWhenWasInvoked == 1
 
     context "chaining Then statements", ->
       timesGivenWasInvoked = timesWhenWasInvoked = 0
@@ -33,7 +42,7 @@ describe "jasmine-given CoffeeScript API", ->
       .And(-> timesWhenWasInvoked == 1)
       .And(-> timesGivenWasInvoked == 1)
       .And(-> timesWhenWasInvoked == 1)
-      And -> timesWhenWasInvoked == 2
+      Then -> timesWhenWasInvoked == 2
 
   describe "And", ->
     context "following a Given", ->

--- a/src/jasmine-given.coffee
+++ b/src/jasmine-given.coffee
@@ -4,6 +4,9 @@ Adds a Given-When-Then DSL to jasmine as an alternative style for specs
 site: https://github.com/searls/jasmine-given
 ###
 ((jasmine) ->
+
+  mostRecentlyUsed = null
+
   stringifyExpectation = (expectation) ->
     matches = expectation.toString().replace(/\n/g,'').match(/function\s?\(\)\s?{\s*(return\s+)?(.*?)(;)?\s*}/i)
     if matches and matches.length >= 3 then matches[2] else ""
@@ -40,12 +43,11 @@ site: https://github.com/searls/jasmine-given
         else
           throw new Error("Unfortunately, the variable '#{assignResultTo}' is already assigned to: #{context[assignResultTo]}")
 
+  mostRecentExpectations = null
+
   root.Then = (expectationFunction) ->
-    mostRecentlyUsed = root.Then
-    expectations = [ expectationFunction ]
-    subsequentThen = (additionalExpectation) ->
-      expectations.push additionalExpectation
-      this
+    mostRecentlyUsed = root.subsequentThen
+    mostRecentExpectations = expectations = [ expectationFunction ]
 
     it "then #{stringifyExpectation(expectations)}", ->
       i = 0
@@ -54,6 +56,10 @@ site: https://github.com/searls/jasmine-given
         i++
 
     Then: subsequentThen, And: subsequentThen
+
+  root.subsequentThen = (additionalExpectation) ->
+    mostRecentExpectations.push additionalExpectation
+    this
 
   mostRecentlyUsed = root.Given
   root.And = ->


### PR DESCRIPTION
Hi again.  To be able to chain `Then`s without needing parentheses, I got `And` working with `Then`

```
Then -> timesGivenWasInvoked == 1
And -> timesWhenWasInvoked == 1
And -> timesGivenWasInvoked == 1
And -> timesWhenWasInvoked == 1
```

I took the liberty of removing the doc of the paren-chaining version from the README, but it's retained in the code and specs for backwards compatibility.
