### PR TITLE
Fixed issue with Protractor when done callback is used.

### DIFF
--- a/app/js/jasmine-given.coffee
+++ b/app/js/jasmine-given.coffee
@@ -54,7 +54,7 @@
     mostRecentExpectations = expectations = [expectationFunction]
     mostRecentStacks = stacks = [errorWithRemovedLines("failed expectation", 3)]
 
-    itFunction "then #{label ? stringifyExpectation(expectations)}", (jasmineDone) ->
+    itFunction "then #{label ? stringifyExpectation(expectations)}", doneWrapperFor expectationFunction, (jasmineDone) ->
       userCommands = [].concat(whenList, invariantList, wrapAsExpectations(expectations, stacks))
       new Waterfall(userCommands, jasmineDone).flow()
 
@@ -110,13 +110,11 @@
   class Waterfall
     constructor: (functions = [], @finalCallback = ->) ->
       @functions = cloneArray(functions)
-      @finalCallbackNeeded = false
 
     flow: ->
-      return (if @finalCallbackNeeded then @finalCallback() else null) if @functions.length == 0
+      return @finalCallback() if @functions.length == 0
       func = @functions.shift()
       if func.length > 0
-        @finalCallbackNeeded = true
         func(=> @flow() )
       else
         func()

--- a/spec-e2e/basic-usage.coffee
+++ b/spec-e2e/basic-usage.coffee
@@ -109,6 +109,14 @@ describe "Basic Given-When-Then usage", ->
       Then -> expect(@result.stdout).toContain("then this.things.length === 2")
       And -> expect(@result.stdout).toContain("# tests 1")
 
+    describe "async And following sync Then", ->
+      Given -> createSpec """
+        describe '', ->
+          Then ->
+          And (done) -> setTimeout((-> expect(0).toEqual(1); done()), 0)
+      """
+      Then "never completes", -> expect(@result.stdout).toContain("# fail  0")
+
     describe "Givens before Whens", ->
       Given -> createSpec """
         describe '', ->

--- a/spec/implementation-spec.coffee
+++ b/spec/implementation-spec.coffee
@@ -62,7 +62,7 @@ describe "jasmine-given implementation", ->
         context "the when does not call its done()", ->
           beforeEach ->
             When (done) ->
-            Then(@then)
+            Then (done) -> @then(); done()
           it '', ->
             specImplementation = it.calls[0].args[1]
             doneProvidedByJasmineRunner = jasmine.createSpy("done")
@@ -73,7 +73,7 @@ describe "jasmine-given implementation", ->
         context "the when does indeed call its done()", ->
           beforeEach ->
             When (done) -> done()
-            Then(@then)
+            Then (done) -> @then(); done()
           it '', ->
             specImplementation = it.calls[0].args[1]
             doneProvidedByJasmineRunner = jasmine.createSpy("done")
@@ -93,7 +93,7 @@ describe "jasmine-given implementation", ->
             Invariant -> inc()
             When (done) -> inc(done)
             And -> inc()
-            Then -> inc()
+            Then (done) -> inc(done)
             And -> inc()
             And (done) -> inc(done)
             And -> inc()

--- a/spec/waterfall-spec.coffee
+++ b/spec/waterfall-spec.coffee
@@ -19,13 +19,13 @@ describe "Waterfall", ->
     When -> new Waterfall(packFunctions(128000, -> counter++), ->).flow()
     Then -> expect(counter).toBe(128000)
 
-  context "final fn does not run for sync functions", ->
+  context "final fn runs last", ->
     counter = null
     countDuringFinal = null
     Given -> counter = 0
     Given -> @finalFn = -> countDuringFinal = 100
     When -> new Waterfall(packFunctions(100, -> counter++), @finalFn).flow()
-    Then -> expect(countDuringFinal).toBeNull()
+    Then -> expect(countDuringFinal).toBe(counter)
 
   context "with async functions", ->
     counter = null


### PR DESCRIPTION
Starting in Protractor v0.21.0, when done is called, an error is thrown. (See: https://github.com/angular/protractor/blob/439ed451d83968f38bc5a2cf1a726b889e677d49/jasminewd/index.js) This is to prevent the mixing of callbacks with promises for async tests. Since jasmine-given always eventually calls done(), e2e protractor tests are broken.

This fix simply prevents the final callback if there were no done callbacks in any of the original expectations, which I believe should be the expected behavior anyway.
