### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,6 @@
 #ignore node_modules, as the node project is not "deployed" per se: http://www.mikealrogers.com/posts/nodemodules-in-git.html
 /node_modules
 
-/dist
 /generated
 
 .sass-cache


### PR DESCRIPTION
Unignored /dist so non-node based projects can consume jasmine-given, as mentioned in #34
