### PR TITLE
Correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,5 @@
     "type": "git",
     "url": "https://github.com/searls/jasmine-given.git"
   },
-  "licenses": [
-    {
-      "name": "Apache License 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
For some reason `package.json` list the project as using the Apache license, while `LICENSE.txt` specifies the MIT license. This commit corrects that.
