### PR TITLE
Add failing spec for When with done() and Then with no done()

### DIFF
--- a/spec/implementation-spec.coffee
+++ b/spec/implementation-spec.coffee
@@ -81,6 +81,17 @@ describe "jasmine-given implementation", ->
             expect(@then).toHaveBeenCalled()
             expect(doneProvidedByJasmineRunner).toHaveBeenCalled()
 
+        context "the when calls its done() and the then has no done", ->
+          beforeEach ->
+            When (done) -> done()
+            Then -> @then()
+          it '', ->
+            specImplementation = it.calls[0].args[1]
+            doneProvidedByJasmineRunner = jasmine.createSpy("done")
+            specImplementation(doneProvidedByJasmineRunner)
+            expect(@then).toHaveBeenCalled()
+            expect(doneProvidedByJasmineRunner).toHaveBeenCalled()
+
         context "has a boatload of commands", ->
           beforeEach ->
             @callCount = 0


### PR DESCRIPTION
In my app, I tried something like

```
When (done) -> _.defer -> done()
Then   -> ...my expectation...
```

But somehow my expectation never gets run, and Jasmine writes an error to the console:

```
Spec '...my expectation...' has no expectations.
```

I thought I'd try to debug it in jasmine-given, so started by adding a spec to test When(done) followed by Then [no done].  I thought that the spec would fail because the then() spy wasn't called.  The spec _does_ fail, but it reports that the done() spy wasn't called!   

I'm not sure what's going on, and unfortunately don't have the time right now to dive into debugging it.
But I figured I'd at least bring it to your attention.
